### PR TITLE
Fix compilation under MacOS and make it easy to run the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ the CRT screen frame around the viewport does not appear.
 
 ## Platform support
 
-These bindings have been tested on Linux and Windows.
-WebAssembly and Mac OS support is currently not guaranteed
+These bindings have been tested on Linux, Windows and MacOS Monterey (x86).
+WebAssembly support is currently not guaranteed
 (but your assistance on this would be greatly appreciated!).
 
 ## Building

--- a/dos-like-sys/build.rs
+++ b/dos-like-sys/build.rs
@@ -74,7 +74,11 @@ fn compute_include_paths(fallback_path: impl AsRef<Path>) -> Vec<PathBuf> {
         include_paths.push(PathBuf::from("/usr/include"));
     }
 
-    if !(target_os == "linux" || target_os == "macos") {
+    if host_os == "darwin" {
+        include_paths.push(PathBuf::from("/usr/local/include/SDL2"));
+    }
+
+    if !(target_os == "linux" || target_os == "darwin") {
         return include_paths;
     }
 
@@ -137,7 +141,11 @@ fn link() {
     }
 
     println!("cargo:rustc-flags=-l GLEW");
-    println!("cargo:rustc-flags=-l GL");
+    if cfg!(target_os = "macos") {
+        println!("cargo:rustc-link-lib=framework=OpenGL");
+    } else {
+        println!("cargo:rustc-flags=-l GL");
+    }
 }
 
 #[cfg(feature = "use-pkgconfig")]


### PR DESCRIPTION
This PR achieves two things:
1. it fixes compilation under x86-based MacOS (tested on MacOS 12.3.1, with dependencies installed according to the dos-like installation instructions)
2. it makes it easy to run the examples, by leveraging cargo. Simply `cd examples/rotozoom && cargo run`. Downside is that the example source code has been modified such that the examples search for their assets in a nested subdirectory of a parent directory (e.g. `../../dos-like-sys/dos-like/files/sound/soundcard.wav`) which is arguably a little awkward.

Note that I have not verified that this does not break anything, and neither do I know if this works on ARM Macs. But "it works on my machine"!